### PR TITLE
Fixing AttributeError: '_MachineState' object has no attribute 'child…

### DIFF
--- a/acora/_acora.py
+++ b/acora/_acora.py
@@ -77,7 +77,7 @@ class _MachineState(object):
 
 
 def build_MachineState(state_id, matches=None):
-    state = _MachineState.__new__(_MachineState)
+    state = _MachineState()
     state.id = state_id
     state.matches = [] if matches is None else matches
     return state


### PR DESCRIPTION
When executing test.py, got error AttributeError: '_MachineState' object has no attribute 'children'.  The problem being in the function build_MachineState, the object hasn't been initialized. Fixing that error